### PR TITLE
added SIGWINCH header support for macOS

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,6 +7,10 @@ ifeq ($(OS),Linux)
 	FLAGS+=-D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700
 endif
 
+ifeq ($(OS),Darwin)
+    FLAGS += -g -D_DARWIN_C_SOURCE
+endif
+
 INCLUDED=/usr/include
 LIBD=/usr/lib
 

--- a/src/termbox.c
+++ b/src/termbox.c
@@ -25,6 +25,11 @@
 #define LAST_ATTR_INIT 0xFFFFFFFF
 #define ENOUGH_DATA_FOR_INPUT_PARSING 128
 
+#ifndef SIGWINCH
+#define SIGWINCH 28  /* window size changes */
+#define SIGINFO 29 /* information request */
+#endif
+
 struct cellbuf
 {
   int width;


### PR DESCRIPTION
couldn't get jermbox to compile on macOS because it was missing SIGWINCH. 

tweaked the termbox.c file to have the approprite info as found via a bunch of googling from people having the same problem on other packages. This seemed to fix it, but I'm not a C geek. 