### PR TITLE
fix millisecond timeout in tb_peek_event

### DIFF
--- a/src/termbox.c
+++ b/src/termbox.c
@@ -343,8 +343,8 @@ tb_peek_event(struct tb_event* event, int timeout)
 {
   struct timeval tv;
   /* timeout / 1000 */
-  tv.tv_sec = timeout >> 3;
-  tv.tv_usec = (timeout - (tv.tv_sec << 3)) << 3;
+  tv.tv_sec = timeout/1000;
+  tv.tv_usec = (timeout % 1000) * 1000;
   return wait_fill_event(event, &tv);
 }
 


### PR DESCRIPTION
Timeout for tb_peek_event did not work correctly, this should fix it.